### PR TITLE
ci(github): set api-level to 33 in workflow e2e-android.yml

### DIFF
--- a/.github/workflows/e2e-android.yml
+++ b/.github/workflows/e2e-android.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Detox test
         uses: reactivecircus/android-emulator-runner@v2
         with:
-          api-level: 31
+          api-level: 33
           arch: x86_64
           avd-name: ${{ steps.device.outputs.AVD_NAME }}
           script: yarn detox test --configuration ${{ env.DETOX_CONFIGURATION }} --headless --record-logs all --take-screenshots failing


### PR DESCRIPTION
## What is the motivation for this pull request?

ci(github): set api-level to 33 in workflow e2e-android.yml

## What is the current behavior?

api-level 31

## What is the new behavior?

api-level 33

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] Tests
- [ ] Documentation