### PR TITLE
ci(github): cache gradle and avd in e2e-android.yml

### DIFF
--- a/.github/workflows/e2e-android.yml
+++ b/.github/workflows/e2e-android.yml
@@ -6,6 +6,7 @@ jobs:
     runs-on: macos-latest
     env:
       DETOX_CONFIGURATION: android.emu.release
+      API_LEVEL: 33
 
     steps:
       - name: Checkout repository
@@ -27,6 +28,27 @@ jobs:
           distribution: temurin
           java-version: 17
 
+      - name: Gradle cache
+        uses: gradle/gradle-build-action@v2
+
+      - name: AVD cache
+        uses: actions/cache@v3
+        id: avd-cache
+        with:
+          path: |
+            ~/.android/avd/*
+            ~/.android/adb*
+          key: avd-${{ env.API_LEVEL }}
+
+      - name: Create AVD and generate snapshot for caching
+        if: steps.avd-cache.outputs.cache-hit != 'true'
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: ${{ env.API_LEVEL }}
+          disable-animations: false
+          emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+          force-avd-creation: false
+
       - name: Cache Detox build
         id: cache-detox-build
         uses: actions/cache@v3
@@ -46,9 +68,12 @@ jobs:
       - name: Detox test
         uses: reactivecircus/android-emulator-runner@v2
         with:
-          api-level: 33
+          api-level: ${{ env.API_LEVEL }}
           arch: x86_64
           avd-name: ${{ steps.device.outputs.AVD_NAME }}
+          disable-animations: true
+          emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+          force-avd-creation: false
           script: yarn detox test --configuration ${{ env.DETOX_CONFIGURATION }} --headless --record-logs all --take-screenshots failing
 
       - name: Upload artifacts

--- a/.github/workflows/e2e-android.yml
+++ b/.github/workflows/e2e-android.yml
@@ -5,8 +5,9 @@ jobs:
   e2e-android:
     runs-on: macos-latest
     env:
-      DETOX_CONFIGURATION: android.emu.release
       API_LEVEL: 33
+      ARCH: x86_64
+      DETOX_CONFIGURATION: android.emu.release
 
     steps:
       - name: Checkout repository
@@ -45,6 +46,7 @@ jobs:
         uses: reactivecircus/android-emulator-runner@v2
         with:
           api-level: ${{ env.API_LEVEL }}
+          arch: ${{ env.ARCH }}
           disable-animations: false
           emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           force-avd-creation: false
@@ -70,7 +72,7 @@ jobs:
         uses: reactivecircus/android-emulator-runner@v2
         with:
           api-level: ${{ env.API_LEVEL }}
-          arch: x86_64
+          arch: ${{ env.ARCH }}
           avd-name: ${{ steps.device.outputs.AVD_NAME }}
           disable-animations: true
           emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none

--- a/.github/workflows/e2e-android.yml
+++ b/.github/workflows/e2e-android.yml
@@ -48,6 +48,7 @@ jobs:
           disable-animations: false
           emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           force-avd-creation: false
+          script: echo 'Generated AVD snapshot for caching.'
 
       - name: Cache Detox build
         id: cache-detox-build


### PR DESCRIPTION
## What is the motivation for this pull request?

ci(github): cache gradle and avd in e2e-android.yml

https://github.com/ReactiveCircus/android-emulator-runner#usage--examples

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] Tests
- [ ] Documentation